### PR TITLE
Added ability to configure User schema ID type via options

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -6,7 +6,7 @@ Schema   = mongoose.Schema
 module.exports = rattlePlugin = (schema, options) ->
   options = {} if (!options)
   options.UserShemaName = 'User' if (!options.UserShemaName)
-  options.ObjectId = Schema.Types.ObjectId if (!options.ObjectId)
+  options.UserIdType = Schema.Types.ObjectId if (!options.UserIdType)
 
   # Schema strategies for embedded comments
   #
@@ -14,15 +14,15 @@ module.exports = rattlePlugin = (schema, options) ->
 
   CommentSchema = new Schema
     message:       type: String, required: true, max: 2000, min: 1
-    creator:       type: options.ObjectId, ref: options.UserShemaName, required: true
-    likes:         [type: options.ObjectId, ref: options.UserShemaName]
+    creator:       type: options.UserIdType, ref: options.UserShemaName, required: true
+    likes:         [type: options.UserIdType, ref: options.UserShemaName]
     likesCount:    type: Number, default: 0
     dateCreation:  type: Date
     dateUpdate:    type: Date
 
   schema.add
-    creator:       type: options.ObjectId, ref: options.UserShemaName, required: true
-    likes:         [type: options.ObjectId, ref: options.UserShemaName]
+    creator:       type: options.UserIdType, ref: options.UserShemaName, required: true
+    likes:         [type: options.UserIdType, ref: options.UserShemaName]
     likesCount:    type: Number, default: 0
     comments:      [CommentSchema]
     dateCreation:  type: Date


### PR DESCRIPTION
Hey,

I've added ability to configure creator ID type to something other than Schema.Types.ObjectId. I needed it in my project, I think it can be useful for other people as well. 

Good job with the plugin anyway!
Thanks,
Matus
