### PR TITLE
Fixed: setting field "likesCount" for comment likes

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -37,6 +37,9 @@ module.exports = rattlePlugin = (schema, options) ->
     this.dateUpdate = moment().toDate()
     this.likesCount = this.likes.length
     next()
+  CommentSchema.pre "save", (next) ->
+    this.likesCount = this.likes.length
+    next()
 
   ####################################################################
   # statics

--- a/test/unit/index.coffee
+++ b/test/unit/index.coffee
@@ -258,16 +258,19 @@ describe "MongooseRattlePlugin", ->
       it "add one user like if user doesn't already liked and comment exists", (done) ->
         thingy.addLikeToComment commentorUserId, commentId, (err, updatedThingy) ->
           assert.equal 1, updatedThingy.getComment(commentId).likes.length
+          assert.equal 1, updatedThingy.getComment(commentId).likesCount
           done()
       it "not add an other user like if user already liked and comment exists", (done) ->
         thingy.addLikeToComment commentorUserId, commentId, (err, updatedThingy) ->
           thingy.addLikeToComment commentorUserId, commentId, (err, updatedThingy) ->
             assert.equal 1, updatedThingy.getComment(commentId).likes.length
+            assert.equal 1, updatedThingy.getComment(commentId).likesCount
             done()
       it "not add an other user like if user already liked and comment exists when userId param is a string", (done) ->
         thingy.addLikeToComment String(commentorUserId), commentId, (err, updatedThingy) ->
           thingy.addLikeToComment commentorUserId, commentId, (err, updatedThingy) ->
             assert.equal 1, updatedThingy.getComment(commentId).likes.length
+            assert.equal 1, updatedThingy.getComment(commentId).likesCount
             done()
 
     describe "document.removeLikeFromComment(userId, commentId, callback)", ->
@@ -290,14 +293,17 @@ describe "MongooseRattlePlugin", ->
       it "not affect current likes list if user didn'nt already liked", (done) ->
         thingy.removeLikeFromComment new ObjectId(), commentId, (err, updatedThingy) ->
           assert.equal 2, updatedThingy.getComment(commentId).likes.length
+          assert.equal 2, updatedThingy.getComment(commentId).likesCount
           done()
       it "remove user like from likes list if user already liked", (done) ->
         thingy.removeLikeFromComment commentorUserId, commentId, (err, updatedThingy) ->
           assert.equal 1, updatedThingy.getComment(commentId).likes.length
+          assert.equal 1, updatedThingy.getComment(commentId).likesCount
           done()
       it "remove user like from likes list if user already liked when userId param is a string", (done) ->
         thingy.removeLikeFromComment String(commentorUserId), commentId, (err, updatedThingy) ->
           assert.equal 1, updatedThingy.getComment(commentId).likes.length
+          assert.equal 1, updatedThingy.getComment(commentId).likesCount
           done()
 
   describe "Plugin statics", ->


### PR DESCRIPTION
Hey Damien,

I've noticed that field "likesCount" for comment likes was not changing at all, no matter how many "likes" there was in array. So I did this little fix. Checking for this variable was not in tests so I've added that too.

Cheers!
Matus
